### PR TITLE
Correct Backlinks + LLM Mentions to pay-as-you-go (DataForSEO 2026-07-01)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.2 - 2026-07-08
+
+- Corrected Backlinks and LLM Mentions access: DataForSEO moved both to pay-as-you-go on 2026-07-01 and removed the $100/mo minimums.
+- Reframed 40204 as a defined legacy code for those modules; pay-as-you-go accounts now receive 20000 Ok in the 2026-07-08 re-probe.
+- Updated hub/dashboard references and source ledger to cite the new pricing update and recorded live fixtures.
+
 ## 1.0.1 - 2026-06-26
 
 - Mega review pass: 7-agent coverage/accuracy/structure audit + adversarial consolidation (37 findings, 0 blockers).

--- a/references/current-requirements.md
+++ b/references/current-requirements.md
@@ -2,10 +2,12 @@
 
 These facts drift and are re-verified monthly, and again before every release. Captured 2026-06-26
 from official documentation plus a $5-capped live API test pass against the production endpoint.
+Backlinks and LLM Mentions access was re-verified live on 2026-07-08.
 
 ## Refresh Cadence
 Monthly for endpoint, parameter, and pricing drift; re-verify cost and authentication facts before
-every release. Pricing figures below are live-observed on 2026-06-26 and supersede any cached tier table.
+every release. Pricing figures below are live-observed on 2026-06-26; DataForSEO adjusted rates across
+selected APIs on 2026-07-01, so refresh exact figures before scaling.
 
 ## Required Source Standard
 Use official, primary, vendor, or API documentation first. Record URL, retrieval date, version,
@@ -45,32 +47,37 @@ deprecation notes, and confidence.
 Full per-call ledger: `.raw/sources/dataforseo-research/_cost-log.json` (39 endpoints tested live, total spend $0.85 of a $5 cap).
 
 ## Access notes observed during live testing
-The Backlinks API and the AI Optimization LLM Mentions endpoints returned status 40204 (access denied)
-on the test account: both require an active add-on subscription separate from pay-as-you-go credit.
-Their request and response shapes are still documented from the official docs in
-`.raw/sources/dataforseo-research/backlinks/` and `.../ai-optimization/`.
+The Backlinks API and the AI Optimization LLM Mentions endpoints returned status 40204 on 2026-06-26,
+when those two modules were still subscription-gated. DataForSEO removed the remaining monthly
+commitments on 2026-07-01 and moved all endpoints to pay-as-you-go. The 40204 result is now legacy
+for these modules.
 
-**Subscription status (re-verified 2026-06-26): NOT removed.** A claim that DataForSEO dropped the
-Backlinks subscription around May 2026 was checked against the official pricing page, the help-center
-"Backlinks API pricing & subscription explained" article, AND a live API re-probe, and is false/unconfirmed.
-- **Backlinks API:** still a **$100/month prepaid minimum**, credited to account balance and spendable on
-  any DataForSEO API (not a sunk access fee). Still 40204-gated until activated. The minimum is **waived
-  only when Backlinks is called via the Make.com, n8n, or Google Sheets connectors** (long-standing wording,
-  not a 2026 change). Activation is a one-time dashboard action at
-  **https://app.dataforseo.com/backlinks-subscription** (Plans and Subscriptions -> Backlinks API ->
-  Activate -> Gain Access, then the payment form); it does not turn on automatically from balance.
-- **LLM Mentions API:** a **separate, unchanged $100/month** subscription; activating one does not unlock
-  the other. Also 40204-gated; usage priced $0.10/request + $0.001/row.
+**Pay-as-you-go status (re-verified 2026-07-08): active.** Gated through 2026-06-26; removed 2026-07-01
+when DataForSEO moved all APIs to pay-as-you-go.
+- **Backlinks API:** no subscription and no activation step. Live re-probe returned `20000 Ok` for
+  `/v3/backlinks/summary/live` and `/v3/backlinks/bulk_ranks/live`; fixtures:
+  `.raw/sources/dataforseo-research/backlinks/fixtures/summary-live.json` and
+  `.raw/sources/dataforseo-research/backlinks/fixtures/bulk_ranks-live.json`.
+- **LLM Mentions API:** no subscription and no activation step. Usage remains per request and per row,
+  roughly $1.1 per 1,000 data rows. Live re-probe returned `20000 Ok`
+  for `/v3/ai_optimization/llm_mentions/search/live`; fixture:
+  `.raw/sources/dataforseo-research/ai-optimization/fixtures/llm-mentions-search.json`.
+- Probe cost log: `.raw/sources/dataforseo-research/_cost-log-2026-07-08-reprobe.json`.
+- The former Make.com, n8n, and Google Sheets connector waiver is historical only because there is
+  no monthly minimum left to waive.
 
 ### Recent changes (2026)
-Newest first; official update publication dates (source https://dataforseo.com/updates, retrieved 2026-06-26):
+Newest first; official update publication dates (source https://dataforseo.com/updates, retrieved 2026-07-08):
+- **2026-07-01** - DataForSEO moved all endpoints to **100% pay-as-you-go**, removed the Backlinks
+  and LLM Mentions monthly commitments, and adjusted rates across selected APIs.
 - **2026-06-10** - Amazon Merchant API gains real-time **Live endpoints** (previously task-based only).
 - **2026-05-28** - **LLM Scraper (ChatGPT)** now returns **ad results** (sponsored placements in ChatGPT answers).
 - **2026-05-05** - **API v2 fully closed**; no new v2 requests (task_get had a ~1-month grace window). v3 only.
 - **2026-04-27** - **OnPage Lighthouse API**: seven new browser-simulation parameters.
 - **2026-04-21** - **OnPage uncrawlable-resources** endpoint plus expanded summary data.
 
-Sources: https://docs.dataforseo.com/v3/backlinks/overview/ (retrieved 2026-06-26);
-https://dataforseo.com/help-center/backlinks-api-pricing-explained (retrieved 2026-06-26);
-https://dataforseo.com/help-center/llm-mentions-api-subscription-explained (retrieved 2026-06-26);
-https://app.dataforseo.com/backlinks-subscription (retrieved 2026-06-26).
+Sources: https://dataforseo.com/update/pricing-update-in-dataforseo-apis (retrieved 2026-07-08);
+https://docs.dataforseo.com/v3/backlinks/overview/ (retrieved 2026-06-26);
+historical comparison pages retrieved 2026-06-26:
+https://dataforseo.com/help-center/backlinks-api-pricing-explained and
+https://dataforseo.com/help-center/llm-mentions-api-subscription-explained.

--- a/references/dashboard-map.json
+++ b/references/dashboard-map.json
@@ -3,7 +3,7 @@
   "app": "SEOus",
   "app_origin": "http://localhost:3000",
   "brain_vault": "../DataForSEO Brain/wiki",
-  "generated": "2026-06-26",
+  "generated": "2026-07-08",
   "groups": [
     {
       "key": "search-serp",
@@ -36,8 +36,8 @@
       "capabilities": ["cap-backlinks-api", "cap-backlinks-bulk-metrics"],
       "playbook": "play-backlink-audit",
       "default_mode": "standard",
-      "gated": true,
-      "gate_note": "Backlinks API requires a $100/mo add-on subscription; returns 40204 on pay-as-you-go. SEOus shows a graceful 'subscription required' state."
+      "gated": false,
+      "gate_note": "Backlinks API is pay-as-you-go since 2026-07-01, with no subscription or activation step; live re-probe returns live data."
     },
     {
       "key": "technical-onpage",
@@ -69,8 +69,8 @@
       "platforms": ["plat-ai-assistants"],
       "playbook": "play-ai-visibility-tracking",
       "default_mode": "live",
-      "gated_partial": true,
-      "gate_note": "LLM Responses (ChatGPT/Claude/Gemini/Perplexity) are pay-as-you-go accessible. LLM Mentions / Share-of-Voice requires a $100/mo add-on (40204) and is shown gated."
+      "gated_partial": false,
+      "gate_note": "LLM Responses (ChatGPT/Claude/Gemini/Perplexity) and LLM Mentions / Share-of-Voice are pay-as-you-go accessible since 2026-07-01, with no subscription gate."
     },
     {
       "key": "ecommerce-apps",

--- a/references/source-ledger.json
+++ b/references/source-ledger.json
@@ -54,6 +54,21 @@
       ]
     },
     {
+      "id": "dfs-pricing-update-2026-07-01",
+      "title": "Pricing Update in DataForSEO APIs",
+      "url": "https://dataforseo.com/update/pricing-update-in-dataforseo-apis",
+      "type": "official",
+      "source_type": "official",
+      "retrieved": "2026-07-08",
+      "refresh_due": "2026-08-08",
+      "version": "published 2026-07-01",
+      "confidence": "high",
+      "claims": [
+        "DataForSEO cancelled monthly commitments and moved all endpoints to pay-as-you-go on 2026-07-01",
+        "The $100 monthly commitments for Backlinks API and LLM Mentions API were removed"
+      ]
+    },
+    {
       "id": "dfs-auth",
       "title": "DataForSEO authentication",
       "url": "https://docs.dataforseo.com/v3/auth/",
@@ -148,13 +163,13 @@
       "url": "https://docs.dataforseo.com/v3/backlinks/overview/",
       "type": "official",
       "source_type": "official",
-      "retrieved": "2026-06-26",
-      "refresh_due": "2026-07-26",
-      "version": "v3 as of 2026-06-26",
+      "retrieved": "2026-07-08",
+      "refresh_due": "2026-08-08",
+      "version": "v3 as of 2026-07-08",
       "confidence": "high",
       "claims": [
         "Backlinks API is Live POST with bulk endpoints up to 1000 targets",
-        "Backlinks require an add-on subscription (observed 40204 without one)"
+        "Backlinks moved to pay-as-you-go on 2026-07-01 with no add-on subscription; live re-probe on 2026-07-08 returned 20000 Ok for summary/live and bulk_ranks/live"
       ]
     },
     {
@@ -178,13 +193,13 @@
       "url": "https://docs.dataforseo.com/v3/ai_optimization/overview/",
       "type": "official",
       "source_type": "official",
-      "retrieved": "2026-06-26",
-      "refresh_due": "2026-07-26",
-      "version": "v3 as of 2026-06-26",
+      "retrieved": "2026-07-08",
+      "refresh_due": "2026-08-08",
+      "version": "v3 as of 2026-07-08",
       "confidence": "high",
       "claims": [
         "AI Optimization covers LLM Responses, LLM Scraper, LLM Mentions, AI Keyword Data",
-        "LLM Mentions requires an add-on subscription (observed 40204)"
+        "LLM Mentions moved to pay-as-you-go on 2026-07-01 with no add-on subscription; live re-probe on 2026-07-08 returned 20000 Ok for llm_mentions/search/live"
       ]
     },
     {
@@ -203,5 +218,5 @@
       ]
     }
   ],
-  "provenance": "Populated 2026-06-26 from official docs.dataforseo.com/v3 + a $5-capped live API test pass."
+  "provenance": "Populated 2026-06-26 from official docs.dataforseo.com/v3 + a $5-capped live API test pass. Updated 2026-07-08 for the 2026-07-01 pay-as-you-go move and live Backlinks/LLM Mentions re-probe."
 }

--- a/schemas/dataforseo-response-schema.json
+++ b/schemas/dataforseo-response-schema.json
@@ -19,7 +19,7 @@
         "required": ["status_code"],
         "properties": {
           "id": {"type": "string"},
-          "status_code": {"type": "integer", "description": "20000 = Ok, 40204 = subscription required"},
+          "status_code": {"type": "integer", "description": "20000 = Ok, 40204 = subscription required (legacy for Backlinks/LLM Mentions since 2026-07-01 pay-as-you-go)"},
           "status_message": {"type": "string"},
           "cost": {"type": "number"},
           "result_count": {"type": ["integer", "null"]},

--- a/wiki/DataForSEO Brain Home.md
+++ b/wiki/DataForSEO Brain Home.md
@@ -4,7 +4,7 @@ title: "DataForSEO Brain Home"
 domain: dataforseo
 status: stable
 created: 2026-06-26
-updated: 2026-06-26
+updated: 2026-07-08
 tags: [dataforseo, moc, home]
 ---
 
@@ -12,7 +12,7 @@ tags: [dataforseo, moc, home]
 
 Your command center for the **DataForSEO v3 API** - 12 modules, ~200+ endpoints, the task/live queue
 model, and the per-call cost model - wired to **SEOus**, a minimalistic self-hosted dashboard.
-Live-verified 2026-06-26. Full catalog: [[index]] · the eight capability groups below map 1:1 to the SEOus dashboard sidebar (run SEOus locally; the route contract is `references/dashboard-map.json`).
+Live-verified 2026-06-26; Backlinks and LLM Mentions access re-verified 2026-07-08. Full catalog: [[index]] · the eight capability groups below map 1:1 to the SEOus dashboard sidebar (run SEOus locally; the route contract is `references/dashboard-map.json`).
 
 ## 🔎 Search & SERP - 4 capabilities · 1 playbook
 - [[cap-serp-api]] - live + queued SERPs across seven engines; the spine of rank tracking
@@ -32,7 +32,7 @@ Live-verified 2026-06-26. Full catalog: [[index]] · the eight capability groups
 - Decision: [[dec-labs-vs-live-apis]]
 
 ## 🔗 Links & Authority - 2 capabilities · 1 playbook
-- [[cap-backlinks-api]] - link profiles from DataForSEO's own crawler *(add-on gated - 40204)*
+- [[cap-backlinks-api]] - link profiles from DataForSEO's own crawler *(pay-as-you-go since 2026-07-01)*
 - [[cap-backlinks-bulk-metrics]] - bulk rank, referring-domain, and spam metrics
 - Playbook: [[play-backlink-audit]]
 
@@ -49,7 +49,7 @@ Live-verified 2026-06-26. Full catalog: [[index]] · the eight capability groups
 
 ## 🤖 AI / GEO visibility - 3 capabilities · 1 playbook
 - [[cap-ai-optimization-api]] - LLM responses, LLM scraper, and AI keyword data
-- [[cap-llm-mentions-visibility]] - share-of-voice across AI answers *(add-on gated - 40204)*
+- [[cap-llm-mentions-visibility]] - share-of-voice across AI answers *(pay-as-you-go since 2026-07-01)*
 - [[cap-geo-ai-search-optimization]] - the GEO / answer-engine optimization surface
 - Surface: [[plat-ai-assistants]]  ·  Playbook: [[play-ai-visibility-tracking]]
 

--- a/wiki/concepts/cap-account-usage-userdata.md
+++ b/wiki/concepts/cap-account-usage-userdata.md
@@ -5,7 +5,7 @@ domain: dataforseo
 subdomain: platform
 status: stable
 created: 2026-06-26
-updated: 2026-06-26
+updated: 2026-07-08
 tags: [dataforseo, platform, account]
 related:
  - "[[cap-queue-priority-cost-model]]"
@@ -15,10 +15,10 @@ related:
 
 # Account Usage & User Data
 
-> The `appendix/user_data` endpoint returns live balance, rate limits, spend statistics, prices, and subscription expiry dates for real-time account monitoring. Sits under [[index|DataForSEO Brain]] → [[concepts/_index|Concepts]].
+> The `appendix/user_data` endpoint returns live balance, rate limits, spend statistics, prices, and legacy subscription expiry dates for real-time account monitoring. Sits under [[index|DataForSEO Brain]] → [[concepts/_index|Concepts]].
 
 ## Overview
-`GET /v3/appendix/user_data` gives "detailed information about your API usage, prices, spending and other account details." It is the programmatic way to watch balance and limits before and during a run, so pipelines can self-throttle or pause before hitting billing errors. The endpoint is free but rate-limited, so poll it sparingly rather than per request. It also surfaces retention-relevant subscription expiry dates (Backlinks, LLM Mentions).
+`GET /v3/appendix/user_data` gives "detailed information about your API usage, prices, spending and other account details." It is the programmatic way to watch balance and limits before and during a run, so pipelines can self-throttle or pause before hitting billing errors. The endpoint is free but rate-limited, so poll it sparingly rather than per request. It also surfaces legacy subscription expiry fields for Backlinks and LLM Mentions; as of 2026-07-01, those fields no longer gate access because both APIs are pay-as-you-go.
 
 ## What it covers
 - Path/method: `GET https://api.dataforseo.com/v3/appendix/user_data` (Basic auth, no params).
@@ -36,7 +36,7 @@ related:
 - `price` object: pricing information by API.
 - `money` object: live balance and spend.
 - `rates` object: call limits and usage by time grouping.
-- Subscription expiry strings (UTC) for Backlinks and LLM Mentions APIs.
+- Legacy subscription expiry strings (UTC) for Backlinks and LLM Mentions APIs.
 
 ## Cost & method notes
 The endpoint itself is free to call. It is the monitoring half of the cost model: it pairs with balance/limit errors 40200 (insufficient balance), 40203 (daily cost limit), and 40210 (insufficient funds). Standard task results are stored 30 days (free re-collect); Live results are not stored; HTML results 7 days; Page Screenshot URL 1 day; past-retention requests return 40403. See [[cap-queue-priority-cost-model]] and [[cap-status-error-codes]].
@@ -47,14 +47,14 @@ Wire it into spend dashboards and pre-flight checks for [[play-cost-optimized-pi
 ## Gotchas / limits
 - Rate-limited to 6 calls/minute - poll sparingly, not per-request (status/errors endpoints capped at 10/min, `tasks_ready` at 20/min per the live help-center). See [[cap-rate-limits-throughput]].
 - Daily cost caps surface as 40203 when exceeded; set caps to bound spend.
-- Subscription-gated APIs (Backlinks 40204, LLM Mentions 40204) require an active subscription, separate from balance; check the expiry fields.
+- Backlinks and LLM Mentions are now pay-as-you-go; do not block runs on `backlinks_subscription_expiry_date` or `llm_mentions_subscription_expiry_date`. Those fields are legacy account metadata after the 2026-07-01 access change.
 - Spend is also visible in the dashboard, but the endpoint is the programmatic source of truth.
 
 - The endpoint is free but limited to 6 calls/minute; poll sparingly, not per-request.
 - `money.total` is total deposited, `money.balance` is remaining; `limits`/`statistics` give caps and spend by period.
 - `rates` exposes per-function and aggregate call limits by day and minute across all modules.
 - `price` returns pricing information by API for programmatic cost estimates. See [[cap-queue-priority-cost-model]].
-- Subscription expiry fields cover Backlinks and LLM Mentions (UTC). See [[cap-backlinks-api]] and [[cap-llm-mentions-visibility]].
+- Legacy subscription expiry fields cover Backlinks and LLM Mentions (UTC), but they no longer determine current access. See [[cap-backlinks-api]] and [[cap-llm-mentions-visibility]].
 - Balance/limit breaches surface as 40200, 40203, and 40210. See [[cap-status-error-codes]].
 - Retention: Standard results 30 days, Live not stored, HTML 7 days, Page Screenshot URL 1 day; past-retention returns 40403.
 - The result echoes `login` and `timezone`, confirming the active credentials. See [[cap-authentication-security]].
@@ -79,3 +79,4 @@ Wire it into spend dashboards and pre-flight checks for [[play-cost-optimized-pi
 - https://docs.dataforseo.com/v3/appendix/user_data/ (retrieved 2026-06-26)
 - https://docs.dataforseo.com/v3/appendix/errors/ (retrieved 2026-06-26)
 - https://dataforseo.com/help-center/how-long-do-you-keep-results (retrieved 2026-06-26)
+- https://dataforseo.com/update/pricing-update-in-dataforseo-apis (retrieved 2026-07-08)

--- a/wiki/concepts/cap-ai-optimization-api.md
+++ b/wiki/concepts/cap-ai-optimization-api.md
@@ -5,7 +5,7 @@ domain: dataforseo
 subdomain: ai-optimization
 status: stable
 created: 2026-06-26
-updated: 2026-06-26
+updated: 2026-07-08
 tags: [dataforseo, ai-optimization, llm]
 related:
   - "[[cap-llm-mentions-visibility]]"
@@ -18,13 +18,13 @@ related:
 > A data layer for querying LLMs, scraping their consumer answers, and measuring AI search volume. Sits under [[index|DataForSEO Brain]] -> [[concepts/_index|Concepts]].
 
 ## Overview
-The AI Optimization API is DataForSEO's interface to the generative-search era. It is raw infrastructure (no dashboard) split into four endpoint groups: LLM Responses (call models via API), LLM Scraper (scrape the consumer ChatGPT/Gemini web UI), AI Keyword Data (AI search volume), and LLM Mentions (brand/citation visibility, covered separately in [[cap-llm-mentions-visibility]]). It lets teams test what each model says about a brand, collect cited sources, and size AI demand programmatically. Everything is pay-as-you-go with sandbox testing available.
+The AI Optimization API is DataForSEO's interface to the generative-search era. It is raw infrastructure (no dashboard) split into four endpoint groups: LLM Responses (call models via API), LLM Scraper (scrape the consumer ChatGPT/Gemini web UI), AI Keyword Data (AI search volume), and LLM Mentions (brand/citation visibility, covered separately in [[cap-llm-mentions-visibility]]). It lets teams test what each model says about a brand, collect cited sources, and size AI demand programmatically. Everything is pay-as-you-go with sandbox testing available; LLM Mentions joined that model on 2026-07-01 with no subscription or activation step.
 
 ## What it covers
 - **LLM Responses** (`/v3/ai_optimization/{provider}/llm_responses/`): structured answers from ChatGPT, Claude, Gemini, and Perplexity through one interface. ChatGPT/Claude/Gemini support Live and Standard; Perplexity is Live-only (`task_post_supported: false`). Each provider has a `/models/` endpoint that is the source of truth for accepted `model_name` strings: the live `/v3/ai_optimization/claude/llm_responses/models` endpoint currently accepts claude-sonnet-4-6, claude-opus-4-8, claude-sonnet-4-5, and claude-opus-4-5, among others. The static docs page lists older models and lags Anthropic's release cadence, so always re-poll the `/models/` endpoint before pinning a version. Live LLM Responses calls are pay-as-you-go accessible with no subscription (verified 2026-06-26; fixtures captured at `.raw/sources/dataforseo-research/ai-optimization/fixtures/llm-responses-*.json`).
 - **LLM Scraper** (`/v3/ai_optimization/{provider}/llm_scraper/`): scrapes the live ChatGPT and Gemini web interfaces for a keyword, returning the markdown answer, `search_results[]`, `sources[]`, typed `items[]` (text, tables, images, products, local businesses), and `brand_entities[]`. Advanced and HTML output. **Recent change (2026-05-28): the ChatGPT LLM Scraper now returns ad results.** It surfaces the **sponsored / ad placements that appear inside ChatGPT responses**, so the scraped items can now include paid results alongside the organic answer - relevant for tracking how ads show up in AI answers and for GEO competitive monitoring.
 - **AI Keyword Data** (`/v3/ai_optimization/ai_keyword_data/keywords_search_volume/live`): `ai_search_volume` and 12-month `ai_monthly_searches`, calculated from People Also Ask SERP data. Live-only, up to 1,000 keywords.
-- **LLM Mentions** (`/v3/ai_optimization/llm_mentions/`): the brand and citation visibility tracker, split out into its own note [[cap-llm-mentions-visibility]].
+- **LLM Mentions** (`/v3/ai_optimization/llm_mentions/`): the brand and citation visibility tracker, split out into its own note [[cap-llm-mentions-visibility]]. It is pay-as-you-go since 2026-07-01, with no subscription or activation step; `/v3/ai_optimization/llm_mentions/search/live` returned `20000 Ok` in the 2026-07-08 live fixture at `.raw/sources/dataforseo-research/ai-optimization/fixtures/llm-mentions-search.json`.
 - **Reference endpoints**: each provider has a `/models/` endpoint to enumerate available model versions, and AI Keyword Data has `/locations_and_languages/` for valid targeting.
 
 ## Key parameters / inputs
@@ -83,3 +83,5 @@ Use LLM Responses to A/B what models say about your brand vs competitors, LLM Sc
 - https://dataforseo.com/pricing/ai-optimization/llm-scraper (retrieved 2026-06-26)
 - https://dataforseo.com/apis/ai-optimization-api (retrieved 2026-06-26)
 - https://dataforseo.com/updates/category/announcement (retrieved 2026-06-26 - Ad Results Support in LLM Scraper API, published 2026-05-28)
+- https://dataforseo.com/update/pricing-update-in-dataforseo-apis (published 2026-07-01, retrieved 2026-07-08)
+- `.raw/sources/dataforseo-research/ai-optimization/fixtures/llm-mentions-search.json` (captured 2026-07-08; `20000 Ok`)

--- a/wiki/concepts/cap-backlinks-api.md
+++ b/wiki/concepts/cap-backlinks-api.md
@@ -5,7 +5,7 @@ domain: dataforseo
 subdomain: backlinks
 status: stable
 created: 2026-06-26
-updated: 2026-06-26
+updated: 2026-07-08
 tags: [dataforseo, backlinks, link-intelligence]
 related:
   - "[[cap-backlinks-bulk-metrics]]"
@@ -19,10 +19,10 @@ related:
 > The Backlinks API serves link intelligence from DataForSEO's own backlink crawler and index: summary metrics, full backlink lists, anchors, referring domains and networks, competitors, intersections, per-page data, and new/lost time series for any domain, subdomain, or URL. Sits under [[index|DataForSEO Brain]] -> [[concepts/_index|Concepts]].
 
 ## Overview
-This module is DataForSEO's answer to Ahrefs and Majestic: a continuously crawled backlink index queried by REST. You pass a `target` (a domain, a subdomain, or a full URL) and get aggregate link metrics, the actual backlinks, anchor-text breakdowns, the referring domains and their IP networks, link gaps against competitors, and the new-versus-lost dynamics over time. Endpoints are Live POST calls under `/v3/backlinks/{function}/live` (the one exception is the free `GET /v3/backlinks/index`). Note: the Backlinks module is a paid add-on; on the test account every live call returned task status 40204 (the HTTP `status_code` itself was 20000, only the per-task `task_status_code` was 40204; subscription required). See [[cap-status-error-codes]].
+This module is DataForSEO's answer to Ahrefs and Majestic: a continuously crawled backlink index queried by REST. You pass a `target` (a domain, a subdomain, or a full URL) and get aggregate link metrics, the actual backlinks, anchor-text breakdowns, the referring domains and their IP networks, link gaps against competitors, and the new-versus-lost dynamics over time. Endpoints are Live POST calls under `/v3/backlinks/{function}/live` (the one exception is the free `GET /v3/backlinks/index`). As of 2026-07-01, Backlinks is plain pay-as-you-go with no subscription and no activation step; the 2026-06-26 `40204` gate was removed, and live probes on 2026-07-08 returned `20000 Ok` for `summary/live` and `bulk_ranks/live` with real data. See [[cap-status-error-codes]].
 
 ## What it covers
-- `GET /v3/backlinks/index` - **free, no charge**; returns the live index volume (backlinks, pages, domains) plus 12-month growth history. The current live index is **~1.96-2.0 trillion live backlinks across ~198-208 billion pages** (the docs' 800.6B backlinks / 80.8B pages / 770.7M domains figure is a stale example snapshot, not the live count). Use it to verify index scale before buying the add-on; whether the index call itself is add-on-gated was not empirically tested.
+- `GET /v3/backlinks/index` - **free, no charge**; returns the live index volume (backlinks, pages, domains) plus 12-month growth history. The current live index is **~1.96-2.0 trillion live backlinks across ~198-208 billion pages** (the docs' 800.6B backlinks / 80.8B pages / 770.7M domains figure is a stale example snapshot, not the live count). Use it to verify index scale before running paid live pulls.
 - `/v3/backlinks/summary/live` - headline counts: backlinks, referring domains, spam score, attribute distributions.
 - `/v3/backlinks/history/live` - monthly historical metrics from January 2019 to present; the `new_backlinks` / `lost_backlinks` and new/lost referring-domain fields only populate from May 2021 onward.
 - `/v3/backlinks/backlinks/live` - the detailed backlink list with per-link metadata.
@@ -54,18 +54,18 @@ Summary-style responses carry `rank`, `backlinks`, `referring_domains`, `referri
 **Spam score.** `backlinks_spam_score` (group) / `target_spam_score` (domain) is a proprietary 0-100% estimate, not a Google signal, computed from **18 page-level signals** - for example insecure HTTP (+30%), contact info present (-20%), social meta tags present (-15%), plus domain length, TLD reputation, and external/internal link ratios. Bands are **0-30 low, 31-60 medium, 61-100 high**; a group or domain score is the average of its per-page scores.
 
 ## Cost & method notes
-- Endpoints are Live/synchronous; per-request billing. The Backlinks module is a separately gated add-on (the free `index` endpoint aside).
-- **Subscription mechanics:** the add-on carries a **$100/month minimum spend commitment**, but that money is **credited to your account balance** and is spendable on any DataForSEO API - it is a balance commitment to protect the crawl infrastructure, not a sunk access fee. The $100 minimum is **waived** when the Backlinks API is used through the Make.com, n8n, or Google Sheets connectors. Enable it at **Plans and Subscriptions -> Backlinks API -> Activate -> Gain Access**, then complete the dedicated payment form (required even if auto-recharge is already configured). The subscription is **independent of the LLM Mentions add-on** - subscribing to one does not unlock the other; see [[cap-llm-mentions-visibility]].
-- **Per-call pricing (flat across the paid endpoints):** $0.02 per request + $0.00003 per returned row, max 1,000 rows per request - roughly **$0.05 per 1,000 backlinks** (1 request + 1,000 rows = $0.05). That headline figure undercuts Ahrefs (~$5.00/1k) and Semrush (~$2.00/1k); see [[dec-dataforseo-vs-ahrefs-semrush-moz]].
-- In the live cost log, `summary`, `referring_domains`, and `anchors` all returned task status 40204 with `cost: 0.0`, confirming the test account lacks the add-on.
+- Endpoints are Live/synchronous; per-request billing. Since 2026-07-01, Backlinks live endpoints are pay-as-you-go and no separate add-on subscription is required.
+- **Access mechanics:** gated through 2026-06-26; removed 2026-07-01 when DataForSEO moved all APIs to pay-as-you-go. Existing Backlinks subscriptions were auto-cancelled and accounts keep access without a monthly minimum. The old Make.com, n8n, and Google Sheets connector waiver is historical and now moot because there is no minimum left to waive; see [[cap-llm-mentions-visibility]] for the parallel LLM Mentions change.
+- **Per-call pricing (flat across the pay-as-you-go endpoints):** $0.02 per request + $0.00003 per returned row, max 1,000 rows per request - roughly **$0.05 per 1,000 backlinks** (1 request + 1,000 rows = $0.05). That headline figure undercuts Ahrefs (~$5.00/1k) and Semrush (~$2.00/1k); see [[dec-dataforseo-vs-ahrefs-semrush-moz]].
+- In the 2026-06-26 live cost log, `summary`, `referring_domains`, and `anchors` returned task status `40204` with `cost: 0.0`. Re-probed live on 2026-07-08, `/v3/backlinks/summary/live` and `/v3/backlinks/bulk_ranks/live` returned `20000 Ok` with real data; fixtures: `.raw/sources/dataforseo-research/backlinks/fixtures/summary-live.json` and `.raw/sources/dataforseo-research/backlinks/fixtures/bulk_ranks-live.json`.
 - The data comes from DataForSEO's own backlink crawler and index, sourced and refreshed independently. See [[cap-data-collection-methodology]] and [[cap-queue-priority-cost-model]].
 
 ## When to use / how it fits
 This module drives [[play-backlink-audit]] (summary -> referring domains -> new/lost -> bulk spam -> cleanup) and the link side of [[play-competitor-gap-analysis]] (domain/page intersection alongside Labs intersections). For headline metrics across many targets at once, prefer [[cap-backlinks-bulk-metrics]]. Route jobs through [[dec-which-api-for-which-job]] and weigh build-vs-buy against rivals via [[dec-dataforseo-vs-ahrefs-semrush-moz]].
 
 ## Gotchas / limits
-- **Access status (verified live 2026-06-26): the Backlinks subscription was NOT removed.** A rumor that DataForSEO dropped the separate Backlinks subscription around May 2026 is **false/unconfirmed**. Re-checked this session against the official Backlinks pricing page, the "Backlinks API pricing & subscription explained" help-center article, AND a live API re-probe: Backlinks still returns task status **40204** and the activation flow still points to **https://app.dataforseo.com/backlinks-subscription**. It remains a **$100/month prepaid minimum** that is **credited to your account balance** and spendable on any DataForSEO API (a balance commitment to protect the crawl infrastructure, not a sunk access fee). The only waiver is the long-standing connector exception: the minimum is **not required when Backlinks is called via the Make.com, n8n, or Google Sheets connectors** - that wording predates 2026 and is not a policy change. Activation is a **one-time dashboard action** (Plans and Subscriptions -> Backlinks API -> Activate -> Gain Access, then the payment form); it does **not** turn on automatically from account balance. This is the authoritative statement: treat the "removed subscription" claim as debunked unless DataForSEO publishes a formal update. The **LLM Mentions** add-on is a **separate, unchanged $100/month subscription**; subscribing to one does not unlock the other (see [[cap-llm-mentions-visibility]] and [[cap-status-error-codes]]).
-- The add-on gate (status 40204) means no data without the paid subscription; budget for it before building on this module.
+- **Access status timeline:** gated through 2026-06-26; removed 2026-07-01 when DataForSEO moved all APIs to pay-as-you-go. The earlier 2026-06-26 note that the subscription was NOT removed was accurate then, but became false after the published pricing update. Treat `40204` for Backlinks as historical and legacy; a pay-as-you-go account no longer receives it for Backlinks live endpoints verified 2026-07-08. See [[cap-status-error-codes]].
+- No $100/month Backlinks add-on remains; budget for per-request and per-row usage before building on this module.
 - 2000 API calls/min, max 30 simultaneous requests; `offset` past 20000 should switch to a search-after token.
 - Spam score and rank are model estimates, not Google signals; compare against [[ent-ahrefs]] and [[ent-moz]] metrics rather than treating them as authoritative.
 - Historical depth starts January 2019; older link history is not available. The `new_backlinks` / `lost_backlinks` and new/lost referring-domain fields are a narrower window: they only populate from May 2021 onward, so velocity metrics before that date are blank.
@@ -93,7 +93,8 @@ This module drives [[play-backlink-audit]] (summary -> referring domains -> new/
 - https://docs.dataforseo.com/v3/backlinks/summary/live/ (retrieved 2026-06-26)
 - https://docs.dataforseo.com/v3/backlinks/backlinks/live/ (retrieved 2026-06-26)
 - https://docs.dataforseo.com/v3/backlinks/referring_domains/live/ (retrieved 2026-06-26)
-- https://dataforseo.com/help-center/backlinks-api-pricing-explained (retrieved 2026-06-26)
+- https://dataforseo.com/update/pricing-update-in-dataforseo-apis (retrieved 2026-07-08)
+- https://dataforseo.com/help-center/backlinks-api-pricing-explained (retrieved 2026-06-26; subscription mechanics superseded by the 2026-07-01 pricing update)
 - https://dataforseo.com/pricing/backlinks/backlinks (retrieved 2026-06-26)
 - https://app.dataforseo.com/backlinks-subscription (retrieved 2026-06-26)
 - https://dataforseo.com/updates (retrieved 2026-06-26 - no Backlinks subscription removal announced)

--- a/wiki/concepts/cap-backlinks-bulk-metrics.md
+++ b/wiki/concepts/cap-backlinks-bulk-metrics.md
@@ -5,7 +5,7 @@ domain: dataforseo
 subdomain: backlinks
 status: stable
 created: 2026-06-26
-updated: 2026-06-26
+updated: 2026-07-08
 tags: [dataforseo, backlinks, bulk]
 related:
   - "[[cap-backlinks-api]]"
@@ -19,7 +19,7 @@ related:
 > The Backlinks bulk endpoints return headline link metrics (rank, spam score, backlink count, referring domains, new/lost, and a full page summary) for up to 1000 targets in a single request, so you can score a whole list of domains in one call instead of one call per target. Sits under [[index|DataForSEO Brain]] -> [[concepts/_index|Concepts]].
 
 ## Overview
-The bulk family is the cost-efficient sibling of the detailed [[cap-backlinks-api]]. Instead of a deep profile for one target, each bulk endpoint takes a `targets` array (up to 1000 entries) and returns one row of metrics per target. This is the right tool for screening a large prospect list, scoring all competitors at once, or refreshing a dashboard of tracked domains. All endpoints are Live POST calls under `/v3/backlinks/bulk_{metric}/live` and, like the rest of the module, sit behind the paid Backlinks add-on.
+The bulk family is the cost-efficient sibling of the detailed [[cap-backlinks-api]]. Instead of a deep profile for one target, each bulk endpoint takes a `targets` array (up to 1000 entries) and returns one row of metrics per target. This is the right tool for screening a large prospect list, scoring all competitors at once, or refreshing a dashboard of tracked domains. All endpoints are Live POST calls under `/v3/backlinks/bulk_{metric}/live`; since 2026-07-01 they are pay-as-you-go with no Backlinks add-on or activation step.
 
 ## What it covers
 - `/v3/backlinks/bulk_ranks/live` - PageRank-style `rank` (0-1000 or 0-100) per target.
@@ -43,7 +43,7 @@ The bulk family is the cost-efficient sibling of the detailed [[cap-backlinks-ap
 Each endpoint returns a compact, target-keyed row. `bulk_ranks` returns `target` and `rank`; `bulk_spam_score` returns `type`, `target`, `spam_score`; `bulk_backlinks` returns `target`, `backlinks`, `items_count`. `bulk_referring_domains` adds `referring_domains`, `referring_domains_nofollow`, `referring_main_domains`, `referring_main_domains_nofollow`. The new/lost endpoints return `new_backlinks` / `lost_backlinks` or `new_referring_domains` / `lost_referring_domains` (plus main-domain variants). `bulk_pages_summary` is the richest, returning `url`, `rank`, `main_domain_rank`, `backlinks`, `first_seen`, `lost_date`, `backlinks_spam_score`, `broken_backlinks`, `referring_domains`, `referring_ips`, `referring_subnets`, `referring_links_tld`, `referring_links_types`, `referring_links_platform_types`, and `referring_links_countries`.
 
 ## Cost & method notes
-- Live/synchronous; the whole module needs the Backlinks add-on. In the cost log, `bulk_ranks` and `bulk_spam_score` returned status 40204 with `cost: 0.0` because the test account lacks the add-on.
+- Live/synchronous and pay-as-you-go. In the 2026-06-26 cost log, `bulk_ranks` and `bulk_spam_score` returned status `40204` with `cost: 0.0` while the module was still gated. After the 2026-07-01 pay-as-you-go move, `bulk_ranks` was re-probed on 2026-07-08 and returned `20000 Ok` with real data in `.raw/sources/dataforseo-research/backlinks/fixtures/bulk_ranks-live.json`.
 - The economic case: one bulk call covers up to 1000 targets, versus 1000 separate per-target calls. At the 2000 calls/min and 30-simultaneous ceiling, bulk keeps you well under rate limits and cuts request count by up to 1000x. See [[cap-queue-priority-cost-model]] and [[dec-cost-control-strategy]].
 
 ## When to use / how it fits
@@ -54,7 +54,7 @@ A typical sequence is: run `bulk_ranks` and `bulk_spam_score` across the full ca
 ## Gotchas / limits
 - The 1000-target cap is per call, but `bulk_pages_summary` additionally caps at 100 distinct domains even when 1000 items are submitted.
 - New/lost windows cannot exceed 365 days; the default lookback is 30 days.
-- Same add-on gate as the rest of the module: no data without the subscription.
+- No subscription gate remains; bulk endpoints are usable on pay-as-you-go accounts.
 - Metrics are DataForSEO model estimates; benchmark against [[ent-ahrefs]] and [[ent-semrush]] before treating thresholds as absolute.
 - `rank_scale` defaults differ from what a dashboard might show; set `one_hundred` or `one_thousand` explicitly so scores are comparable across runs.
 - Bulk endpoints return one summary row per target, not the underlying links, so a target flagged by `bulk_spam_score` still needs the per-target `backlinks` endpoint to see which links drive the score.
@@ -78,3 +78,5 @@ A typical sequence is: run `bulk_ranks` and `bulk_spam_score` across the full ca
 - https://docs.dataforseo.com/v3/backlinks/bulk_ranks/live/ (retrieved 2026-06-26)
 - https://docs.dataforseo.com/v3/backlinks/bulk_spam_score/live/ (retrieved 2026-06-26)
 - https://docs.dataforseo.com/v3/backlinks/bulk_pages_summary/live/ (retrieved 2026-06-26)
+- https://dataforseo.com/update/pricing-update-in-dataforseo-apis (retrieved 2026-07-08)
+- .raw/sources/dataforseo-research/backlinks/fixtures/bulk_ranks-live.json (captured 2026-07-08)

--- a/wiki/concepts/cap-databases.md
+++ b/wiki/concepts/cap-databases.md
@@ -5,7 +5,7 @@ domain: dataforseo
 subdomain: databases
 status: stable
 created: 2026-06-26
-updated: 2026-06-26
+updated: 2026-07-08
 tags: [dataforseo, databases, bulk-data]
 related:
   - "[[cap-labs-keyword-research]]"
@@ -47,7 +47,7 @@ The deliverable is a dataset dump, not a per-call JSON envelope. SERP databases 
 ## When to use / how it fits
 Choose Databases when you need the whole haystack in your own warehouse: building an internal keyword tool, training models, or running analytics that would be uneconomical as millions of live calls. For targeted, fresh lookups use [[cap-serp-api]] or [[cap-keywords-data-api]]; for cheap pre-indexed analytics without managing dumps, use [[cap-labs-keyword-research]] and [[cap-labs-competitor-research]]. Databases are the bulk extreme of [[play-cost-optimized-pipeline]]; route the choice via [[dec-which-api-for-which-job]].
 
-The decision is essentially build-vs-buy at the storage layer. A live or Labs call gives you a fresh slice on demand with no infrastructure; a database gives you the entire corpus to query offline but shifts ingestion, storage, indexing, and refresh management onto your team. Unified Search and Unified Search Historical bundle Advanced SERP and Keyword data together across 67 regions, which is the closest the catalog comes to a one-stop dataset. The Backlink Summary database is the bulk-download counterpart to the gated [[cap-backlinks-api]], useful when the per-call add-on is uneconomical for your volume.
+The decision is essentially build-vs-buy at the storage layer. A live or Labs call gives you a fresh slice on demand with no infrastructure; a database gives you the entire corpus to query offline but shifts ingestion, storage, indexing, and refresh management onto your team. Unified Search and Unified Search Historical bundle Advanced SERP and Keyword data together across 67 regions, which is the closest the catalog comes to a one-stop dataset. The Backlink Summary database is the bulk-download counterpart to [[cap-backlinks-api]], useful when repeated pay-as-you-go live calls are uneconomical for your volume.
 
 ## Gotchas / limits
 - Freshness lags live APIs by design: 60-90 day SERP/app cycles and monthly keyword updates mean Databases are wrong for near-real-time tracking.

--- a/wiki/concepts/cap-geo-ai-search-optimization.md
+++ b/wiki/concepts/cap-geo-ai-search-optimization.md
@@ -5,7 +5,7 @@ domain: dataforseo
 subdomain: ai-optimization
 status: stable
 created: 2026-06-26
-updated: 2026-06-26
+updated: 2026-07-08
 tags: [dataforseo, geo, ai-optimization]
 related:
   - "[[cap-llm-mentions-visibility]]"
@@ -45,7 +45,7 @@ GEO produces a small set of standard metrics:
 - **Source mix**: roughly 85% of brand mentions come from third-party pages, so earned and UGC sources (the `sources_domain[]` view) must be tracked, not just the owned site.
 
 ## Cost & method notes
-- GEO with DataForSEO is pay-as-you-go infrastructure: LLM Mentions roughly $0.10/request + $0.001/row ($100 minimum monthly), LLM Responses Live roughly $0.0006/task plus model token charges (Standard $0.0002 + $0.01 refundable prepayment), LLM Scraper roughly $0.0012 Standard / $0.0024 Priority / $0.004 Live per page (ChatGPT and Gemini only, approximate), AI Keyword Data roughly $0.01/task + $0.0001/keyword. See [[cap-queue-priority-cost-model]].
+- GEO with DataForSEO is pay-as-you-go infrastructure: LLM Mentions roughly $0.10/request + $0.001/row, about $1.10 per 1,000 rows and no monthly minimum since 2026-07-01; LLM Responses Live roughly $0.0006/task plus model token charges (Standard $0.0002 + $0.01 refundable prepayment), LLM Scraper roughly $0.0012 Standard / $0.0024 Priority / $0.004 Live per page (ChatGPT and Gemini only, approximate), AI Keyword Data roughly $0.01/task + $0.0001/keyword. See [[cap-queue-priority-cost-model]].
 - DataForSEO is cheaper and fully programmable vs finished SaaS dashboards (Profound, Peec AI, Otterly at roughly $29-$499/mo), but you supply the prompt design, scoring logic, and dashboards.
 
 ## When to use / how it fits
@@ -80,3 +80,5 @@ GEO is operationalized as [[play-ai-visibility-tracking]]: sample prompts and pu
 - https://ahrefs.com/blog/ai-brand-visibility-correlations/ (retrieved 2026-06-26)
 - https://searchengineland.com/what-is-generative-engine-optimization-geo-444418 (retrieved 2026-06-26)
 - https://developers.google.com/search/docs/fundamentals/ai-optimization-guide (retrieved 2026-06-26)
+- https://dataforseo.com/update/pricing-update-in-dataforseo-apis (published 2026-07-01, retrieved 2026-07-08)
+- https://dataforseo.com/pricing/ai-optimization/llm-mentions (retrieved 2026-07-08)

--- a/wiki/concepts/cap-llm-mentions-visibility.md
+++ b/wiki/concepts/cap-llm-mentions-visibility.md
@@ -5,7 +5,7 @@ domain: dataforseo
 subdomain: ai-optimization
 status: stable
 created: 2026-06-26
-updated: 2026-06-26
+updated: 2026-07-08
 tags: [dataforseo, ai-optimization, geo]
 related:
   - "[[cap-ai-optimization-api]]"
@@ -46,14 +46,14 @@ The LLM Mentions API (launched 2025-11-11) is DataForSEO's flagship AI-visibilit
 Search returns `total_count`, `current_offset`, `search_after_token`, and `items[]`. Each item carries `platform`, `model_name`, `question`, `answer`, `sources[]` (source_name, snippet, title, domain, url, position, publication_date), `search_results[]`, `ai_search_volume`, `first_response_at`, `last_response_at`, and `brand_entities[]`. The aggregation endpoints return a `total` object plus grouped arrays: `location[]`, `language[]`, `platform[]`, `sources_domain[]`, `search_results_domain[]`, `brand_entities_title[]`, `brand_entities_category[]`. Group elements carry `key`, `mentions`, and `ai_search_volume` (note `impressions` is deprecated and returns null).
 
 ## Cost & method notes
-- Per the AI Optimization page, LLM Mentions is roughly $0.10 per request plus $0.001 per row, with a $100 minimum monthly commitment credited to usage, and about a 2-second turnaround.
+- Per the AI Optimization page, LLM Mentions is pay-as-you-go: roughly $0.10 per request plus $0.001 per row, about $1.10 per 1,000 rows, with no monthly minimum since DataForSEO's 2026-07-01 pricing update.
 - All endpoints are Live-only with one task per call. See [[cap-queue-priority-cost-model]] and [[cap-task-vs-live-execution]].
 
 ## When to use / how it fits
 LLM Mentions is the data engine of [[play-ai-visibility-tracking]] and the GEO loop in [[cap-geo-ai-search-optimization]]. Use Search for evidence (the actual question and answer), Top Domains/Pages to see who AI cites in your category, and Cross Aggregated Metrics to compute Share of Voice across competitors. Practitioner research notes that about 85% of brand mentions come from third-party pages, so the off-domain `sources_domain[]` view matters as much as your own. The answer surfaces are profiled in [[plat-ai-assistants]] and the models in [[ent-llm-model-providers]].
 
 ## Gotchas / limits
-- Subscription-gated: every LLM Mentions endpoint (search, top_domains, top_pages, aggregated_metrics, cross_aggregated_metrics) returns 40204 until you activate the LLM Mentions subscription ($100/mo, credited to your balance and spendable on any DataForSEO API) at app.dataforseo.com/api-access-subscriptions. This is separate from the Backlinks subscription and is NOT auto-activated by balance or auto-recharge; the dedicated payment form must be submitted each month or access lapses. See [[cap-status-error-codes]].
+- Access is now plain pay-as-you-go, with no subscription or activation step. It returned `40204` through 2026-06-26; that gate was removed 2026-07-01 when DataForSEO moved all APIs to pay-as-you-go. A live re-probe on 2026-07-08 returned `20000 Ok` with real data for `/v3/ai_optimization/llm_mentions/search/live`; fixture: `.raw/sources/dataforseo-research/ai-optimization/fixtures/llm-mentions-search.json`. See [[cap-status-error-codes]].
 - ChatGPT coverage uses model GPT-5 and covers United States (location_code 2840) and English only; Google AI Overview (`model_name` always `google_ai_overview`) supports multiple locations and languages and is the broad-coverage platform. The launch announcement notes initial coverage is narrower than the marketing list.
 - Execution up to 120 seconds; 2000 calls/min; one task per call; `offset` max 9,000 (use `search_after_token` beyond 20,000 results).
 - Citation churn is high (industry studies report 40-60% of cited sources change month to month), so trends matter more than any single snapshot. See [[cap-data-collection-methodology]].
@@ -78,7 +78,9 @@ LLM Mentions is the data engine of [[play-ai-visibility-tracking]] and the GEO l
 - https://docs.dataforseo.com/v3/ai_optimization/llm_mentions/search/live/ (retrieved 2026-06-26)
 - https://docs.dataforseo.com/v3/ai_optimization/llm_mentions/top_domains/live/ (retrieved 2026-06-26)
 - https://docs.dataforseo.com/v3/ai_optimization/llm_mentions/cross_aggregated_metrics/live/ (retrieved 2026-06-26)
-- https://dataforseo.com/help-center/llm-mentions-api-subscription-explained (retrieved 2026-06-26)
-- https://app.dataforseo.com/api-access-subscriptions (retrieved 2026-06-26)
+- https://dataforseo.com/update/pricing-update-in-dataforseo-apis (published 2026-07-01, retrieved 2026-07-08)
+- https://dataforseo.com/pricing/ai-optimization/llm-mentions (retrieved 2026-07-08)
+- https://dataforseo.com/help-center/llm-mentions-api-subscription-explained (retrieved 2026-07-08; pricing fields retained, subscription text superseded by the 2026-07-01 update)
+- `.raw/sources/dataforseo-research/ai-optimization/fixtures/llm-mentions-search.json` (captured 2026-07-08; `20000 Ok`)
 - https://dataforseo.com/update/introducing-llm-mentions-api (retrieved 2026-06-26)
 - https://docs.dataforseo.com/v3/ai_optimization-llm_mentions-overview/ (retrieved 2026-06-26)

--- a/wiki/concepts/cap-platform-architecture.md
+++ b/wiki/concepts/cap-platform-architecture.md
@@ -5,7 +5,7 @@ domain: dataforseo
 subdomain: platform
 status: stable
 created: 2026-06-26
-updated: 2026-06-26
+updated: 2026-07-08
 tags: [dataforseo, platform, architecture]
 related:
  - "[[cap-task-vs-live-execution]]"
@@ -58,7 +58,7 @@ Read this first when integrating any module. It underpins every workflow ([[play
 - The official MCP server exposes the same modules to agents over a wrapped interface. See [[cap-mcp-server-integration]].
 - Pre-indexed Databases are a separate delivery channel (S3, SFTP, Google Cloud), not REST task results. See [[cap-databases]].
 - Locations and languages are set per task and validated against helper endpoints. See [[cap-locations-languages-targeting]].
-- Subscription-gated modules (Backlinks, LLM Mentions) return 40204 until the subscription is active. See [[cap-status-error-codes]].
+- All DataForSEO APIs, including Backlinks and LLM Mentions, are pay-as-you-go as of 2026-07-01. The earlier 40204 gate for those two modules is legacy. See [[cap-status-error-codes]].
 
 ## Related
 - [[index]]
@@ -79,3 +79,4 @@ Read this first when integrating any module. It underpins every workflow ([[play
 - https://docs.dataforseo.com/v3/auth/ (retrieved 2026-06-26)
 - https://docs.dataforseo.com/v3/appendix/user_data/ (retrieved 2026-06-26)
 - https://docs.dataforseo.com/v3/appendix/errors/ (retrieved 2026-06-26)
+- https://dataforseo.com/update/pricing-update-in-dataforseo-apis (retrieved 2026-07-08)

--- a/wiki/concepts/cap-status-error-codes.md
+++ b/wiki/concepts/cap-status-error-codes.md
@@ -5,7 +5,7 @@ domain: dataforseo
 subdomain: platform
 status: stable
 created: 2026-06-26
-updated: 2026-06-26
+updated: 2026-07-08
 tags: [dataforseo, platform, errors]
 related:
  - "[[cap-platform-architecture]]"
@@ -18,14 +18,14 @@ related:
 > The dual-layer status system: HTTP codes plus DataForSEO internal `status_code` values (20000 OK, 20100 Task Created, 40xxx client, 50xxx server) and which are retryable. Sits under [[index|DataForSEO Brain]] → [[concepts/_index|Concepts]].
 
 ## Overview
-DataForSEO reports outcome at two layers: the HTTP response code and an internal `status_code` field that appears both at the response top level and per task. A request can be HTTP 200 yet carry a per-task error code (e.g. 40204 "subscription required"), so robust clients must inspect both. Codes group into success (200xx), client errors (40xxx), and server/3rd-party errors (50xxx). Knowing the retryable set is essential for reliable pipelines.
+DataForSEO reports outcome at two layers: the HTTP response code and an internal `status_code` field that appears both at the response top level and per task. A request can be HTTP 200 yet carry a per-task error code, so robust clients must inspect both; for example, 40204 remains a defined "subscription required" code, but is legacy for Backlinks and LLM Mentions after their 2026-07-01 pay-as-you-go move. Codes group into success (200xx), client errors (40xxx), and server/3rd-party errors (50xxx). Knowing the retryable set is essential for reliable pipelines.
 
 ## What it covers
 - HTTP codes: 401 Unauthorized, 402 Payment Required, 404 Not Found, 500 Internal Server Error.
 - Success: 20000 "Ok." (request completed), 20100 "Task Created." (Standard task accepted).
 - Task management (40000-40006): 40000 multiple tasks not allowed, 40006 >100 tasks per POST.
 - Auth/verification (40100-40104): 40100 not authorized, 40102 no search results, 40103 task execution failed (resubmit), 40104 account verification required.
-- Payment/account (40200-40210): 40200 insufficient balance, 40202 rate limit (2000/min), 40203 daily cost limit, 40204 Backlinks subscription required, 40207 IP not whitelisted, 40209 >30 simultaneous, 40210 insufficient funds.
+- Payment/account (40200-40210): 40200 insufficient balance, 40202 rate limit (2000/min), 40203 daily cost limit, 40204 subscription required (legacy for Backlinks and LLM Mentions after 2026-07-01), 40207 IP not whitelisted, 40209 >30 simultaneous, 40210 insufficient funds.
 - Not found (40400-40408): 40401 task doesn't exist, 40403 "Results Expired" (data older than one month), 40404 sandbox missing prepared data, 40408 target URL invalid/404.
 - Validation (40501-40506): 40501 invalid POST field, 40502 empty POST, 40503 invalid POST, 40506 unknown fields.
 - Task status (40601 "Task Handed", 40602 "Task in Queue").
@@ -36,11 +36,12 @@ DataForSEO reports outcome at two layers: the HTTP response code and an internal
 - `tasks_error` counts tasks with errors in a batch response.
 
 ## Response / what you get back
-- Live-observed task-level codes (2026-06-26, `_cost-log.json`): 40204 on Backlinks and LLM Mentions endpoints (subscription not active, $0 charged); 40501 on a malformed Labs `categories_for_domain` and a YouTube SERP call; 40402 on a Google Shopping products call (invalid URL path). Charged tasks all returned 20000.
+- Live-observed task-level codes (2026-06-26, `_cost-log.json`): 40204 on Backlinks and LLM Mentions endpoints (then subscription-gated, $0 charged); 40501 on a malformed Labs `categories_for_domain` and a YouTube SERP call; 40402 on a Google Shopping products call (invalid URL path). Charged tasks all returned 20000.
+- Timeline correction: Backlinks and LLM Mentions were gated through 2026-06-26, but DataForSEO removed the gate on 2026-07-01 when it moved all APIs to pay-as-you-go. Live re-probe on 2026-07-08 returned `20000 Ok` for `/v3/backlinks/summary/live`, `/v3/backlinks/bulk_ranks/live`, and `/v3/ai_optimization/llm_mentions/search/live`.
 - A failed task returns `result_count: 0` and `cost: 0` - you are not billed for errored tasks.
 
 ## Cost & method notes
-Errored tasks are not charged, so cost-control depends on not retrying non-retryable errors blindly. Subscription-gated 40204 (Backlinks, LLM Mentions) means you pay a subscription, not per-call balance. See [[cap-account-usage-userdata]] and [[cap-queue-priority-cost-model]].
+Errored tasks are not charged, so cost-control depends on not retrying non-retryable errors blindly. For Backlinks and LLM Mentions, 40204 is now a legacy signal from the former subscription gate; those modules are per-call pay-as-you-go as of 2026-07-01. See [[cap-account-usage-userdata]] and [[cap-queue-priority-cost-model]].
 
 ## When to use / how it fits
 Build your retry/error matrix from this note before shipping [[play-cost-optimized-pipeline]] or [[play-rank-tracking-pipeline]]. It underpins reliability in [[dec-live-vs-standard-vs-priority]].
@@ -53,7 +54,7 @@ Build your retry/error matrix from this note before shipping [[play-cost-optimiz
 - Failed pingbacks/postbacks can be re-sent via the Webhook Resend endpoint. See [[cap-webhooks-pingback-postback]].
 
 - 40202 maps to the 2000 calls/min ceiling; 40209 to the 30-simultaneous cap. See [[cap-rate-limits-throughput]].
-- 40204 gates the Backlinks and LLM Mentions APIs behind active subscriptions. The official `/appendix/errors/` 40204 message references the Backlinks subscription URL only; LLM Mentions reuses the same code with its own separate $100/mo subscription. See [[cap-backlinks-api]] and [[cap-llm-mentions-visibility]].
+- 40204 stays in the code catalog as "subscription required," but it is legacy for the historically gated Backlinks and LLM Mentions modules. A pay-as-you-go account no longer receives 40204 for those modules after the 2026-07-01 move; if it appears elsewhere, handle it as a product-specific access error. See [[cap-backlinks-api]] and [[cap-llm-mentions-visibility]].
 - 40505 ("Outdated location parameters") fails geo-targeted tasks; refresh from the helper endpoint. See [[cap-locations-languages-targeting]].
 - 40404 ("Sandbox missing prepared data") only occurs in the sandbox environment. See [[cap-sandbox-testing]].
 - 50401 is the Live 120-second timeout; 50402 is the 50-second target-page cap. See [[cap-task-vs-live-execution]].
@@ -81,3 +82,4 @@ Build your retry/error matrix from this note before shipping [[play-cost-optimiz
 - https://docs.dataforseo.com/v3/appendix/errors/ (retrieved 2026-06-26)
 - https://docs.dataforseo.com/v3/ (retrieved 2026-06-26)
 - https://dataforseo.com/help-center/best-practices-live-endpoints-in-dataforseo-api (retrieved 2026-06-26)
+- https://dataforseo.com/update/pricing-update-in-dataforseo-apis (retrieved 2026-07-08)

--- a/wiki/decisions/dec-which-api-for-which-job.md
+++ b/wiki/decisions/dec-which-api-for-which-job.md
@@ -5,7 +5,7 @@ domain: dataforseo
 subdomain: platform
 status: stable
 created: 2026-06-26
-updated: 2026-06-26
+updated: 2026-07-08
 tags: [dataforseo, decision, routing, module-map]
 related:
   - "[[cap-platform-architecture]]"
@@ -55,7 +55,7 @@ DataForSEO exposes 12 modules under one v3 envelope ([[cap-platform-architecture
 ## Gotchas / limits
 - Endpoint paths and costs above are quoted from this brain's own runs and the official pricing pages; verify on your live invoice before scaling.
 - Some jobs have both a live and a pre-indexed path (e.g. SERP vs Labs ranked_keywords) - picking wrong is the main cost leak.
-- Several endpoints returned task-level errors in testing (e.g. 40204 on backlinks, 40402 on merchant) - handle per [[cap-status-error-codes]].
+- Several endpoints returned task-level errors in testing. The 40204 seen on Backlinks in the 2026-06-26 run is legacy after the 2026-07-01 pay-as-you-go move, while 40402 on merchant still needs path handling. Handle per [[cap-status-error-codes]].
 
 ## Worked examples
 - "Rank-track 500 keywords daily" -> SERP Standard High + webhooks, store time series ([[play-rank-tracking-pipeline]]).
@@ -83,3 +83,4 @@ DataForSEO exposes 12 modules under one v3 envelope ([[cap-platform-architecture
 - dataforseo_labs/google/overview - https://docs.dataforseo.com/v3/dataforseo_labs-google-overview/ - retrieved 2026-06-26
 - dataforseo_labs/google/keyword_ideas/live - https://docs.dataforseo.com/v3/dataforseo_labs/google/keyword_ideas/live/ - retrieved 2026-06-26
 - SERP API pricing - https://dataforseo.com/apis/serp-api/pricing - retrieved 2026-06-26
+- DataForSEO pricing update - https://dataforseo.com/update/pricing-update-in-dataforseo-apis - retrieved 2026-07-08

--- a/wiki/flows/play-ai-visibility-tracking.md
+++ b/wiki/flows/play-ai-visibility-tracking.md
@@ -5,7 +5,7 @@ domain: dataforseo
 subdomain: ai-optimization
 status: stable
 created: 2026-06-26
-updated: 2026-06-26
+updated: 2026-07-08
 tags: [dataforseo, ai-optimization, geo]
 related:
   - "[[cap-llm-mentions-visibility]]"
@@ -41,7 +41,7 @@ A brand wants to know how it shows up in AI answers: a GEO program launch, a com
 7. Score and chart: per engine, record mention rate, citation rate, share of voice, position, and sentiment over time; alert on drops.
 
 ## Cost & cadence
-- LLM Mentions is Live-only, priced about $0.10/request + $0.001/row with a $100 minimum monthly commitment; turnaround about 2 seconds. The Mentions API is subscription-gated (`llm_mentions_subscription_expiry_date` in `user_data`; calls fail 40204 without it, as the cost-log shows).
+- LLM Mentions is Live-only and pay-as-you-go, priced about $0.10/request + $0.001/row, roughly $1.10 per 1,000 rows; turnaround about 2 seconds. It returned `40204` through 2026-06-26, then the subscription and activation step were removed on 2026-07-01. A 2026-07-08 re-probe of `/v3/ai_optimization/llm_mentions/search/live` returned `20000 Ok` with real data; fixture: `.raw/sources/dataforseo-research/ai-optimization/fixtures/llm-mentions-search.json`.
 - LLM Responses bills DataForSEO's per-task cost (about $0.0006/task) plus a pass-through `money_spent` for the underlying model tokens. AI Keyword Data bills about $0.0101/task (cost-log: $0.0101).
 - Cadence: mentions/aggregates weekly or monthly (the data has churn but stable patterns); live prompt sampling weekly across the model set.
 
@@ -57,7 +57,7 @@ An AI visibility dashboard per engine: mention rate, citation rate, AI share of 
 
 ## Decisions in play
 - [[dec-which-api-for-which-job]]: LLM Mentions for aggregated brand/citation visibility; LLM Responses for fresh, controllable prompt sampling across models.
-- [[dec-cost-control-strategy]]: LLM Mentions carries a $100 monthly minimum, so design a fixed prompt/target set and cache; LLM Responses adds a pass-through `money_spent` token charge per model.
+- [[dec-cost-control-strategy]]: LLM Mentions bills per request and per row, so design a fixed prompt/target set and cache; LLM Responses adds a pass-through `money_spent` token charge per model.
 - [[dec-dataforseo-vs-ahrefs-semrush-moz]]: DataForSEO is raw GEO infrastructure, not a finished SOV dashboard; you build the scoring and charts.
 
 ## Related
@@ -80,3 +80,6 @@ An AI visibility dashboard per engine: mention rate, citation rate, AI share of 
 - https://docs.dataforseo.com/v3/ai_optimization/chat_gpt/llm_responses/live/ (retrieved 2026-06-26)
 - https://dataforseo.com/update/introducing-llm-mentions-api (retrieved 2026-06-26)
 - https://docs.dataforseo.com/v3/ai_optimization-overview/ (retrieved 2026-06-26)
+- https://dataforseo.com/update/pricing-update-in-dataforseo-apis (published 2026-07-01, retrieved 2026-07-08)
+- https://dataforseo.com/pricing/ai-optimization/llm-mentions (retrieved 2026-07-08)
+- `.raw/sources/dataforseo-research/ai-optimization/fixtures/llm-mentions-search.json` (captured 2026-07-08; `20000 Ok`)

--- a/wiki/flows/play-backlink-audit.md
+++ b/wiki/flows/play-backlink-audit.md
@@ -5,7 +5,7 @@ domain: dataforseo
 subdomain: backlinks
 status: stable
 created: 2026-06-26
-updated: 2026-06-26
+updated: 2026-07-08
 tags: [dataforseo, backlinks, audit]
 related:
   - "[[cap-backlinks-api]]"
@@ -43,14 +43,14 @@ A domain needs a link-health review: a penalty investigation, an M&A due-diligen
 ## Cost & cadence
 - Backlinks endpoints are Live-only and billed per request; pricing is on the Backlinks API page (per-row plus per-request components).
 - Bulk endpoints are the cost lever: `bulk_spam_score` scores up to 1,000 targets in one billed request rather than 1,000 separate calls. The same applies to bulk ranks and bulk new/lost.
-- The Backlinks API is subscription-gated: `backlinks_subscription_expiry_date` appears in `user_data`; without an active subscription calls return error 40204 (the project cost-log shows backlinks calls failing 40204 when unsubscribed).
+- Since 2026-07-01, the Backlinks API is pay-as-you-go with no subscription or activation step. The `backlinks_subscription_expiry_date` field in `user_data` is legacy and irrelevant for access; 2026-07-08 probes returned `20000 Ok` for `summary/live` and `bulk_ranks/live`.
 - Cadence: full audit on demand; monitoring (summary + new/lost) weekly or monthly.
 
 ## Output
 A backlink audit pack: profile summary metrics, ranked referring-domain table, anchor distribution, new/lost velocity chart, and a prioritized disavow + reclamation list. Feeds [[play-competitor-gap-analysis]] for link-gap work.
 
 ## Pitfalls / limits
-- Requires an active Backlinks API subscription; calls fail with 40204 otherwise. Check `user_data` before running.
+- No Backlinks API subscription is required. Check `user_data` for balance and limits before running, not for access.
 - `include_subdomains`, `include_indirect_links`, and `exclude_internal_backlinks` all default to true and materially change counts; set them deliberately and keep them consistent across runs.
 - `rank_scale` defaults to `one_thousand`; switch to `one_hundred` if your reporting expects 0-100.
 - Rate ceiling is 2,000 calls/min and max 30 simultaneous Live requests; max 1,000 items per page and 1,000 targets per bulk call.
@@ -80,3 +80,6 @@ A backlink audit pack: profile summary metrics, ranked referring-domain table, a
 - https://docs.dataforseo.com/v3/backlinks/referring_domains/live/ (retrieved 2026-06-26)
 - https://docs.dataforseo.com/v3/backlinks/bulk_spam_score/live/ (retrieved 2026-06-26)
 - https://docs.dataforseo.com/v3/backlinks/domain_intersection/live/ (retrieved 2026-06-26)
+- https://dataforseo.com/update/pricing-update-in-dataforseo-apis (retrieved 2026-07-08)
+- .raw/sources/dataforseo-research/backlinks/fixtures/summary-live.json (captured 2026-07-08)
+- .raw/sources/dataforseo-research/backlinks/fixtures/bulk_ranks-live.json (captured 2026-07-08)

--- a/wiki/flows/play-competitor-gap-analysis.md
+++ b/wiki/flows/play-competitor-gap-analysis.md
@@ -5,7 +5,7 @@ domain: dataforseo
 subdomain: labs
 status: stable
 created: 2026-06-26
-updated: 2026-06-26
+updated: 2026-07-08
 tags: [dataforseo, labs, backlinks, competitive]
 related:
   - "[[cap-labs-competitor-research]]"
@@ -42,7 +42,7 @@ A team needs a competitive content/link roadmap: a market-entry plan, a quarterl
 
 ## Cost & cadence
 - Labs competitive endpoints bill about $0.0105 per request (cost-log: `domain_intersection`, `ranked_keywords`, `competitors_domain`, `serp_competitors`, `relevant_pages` all $0.0105; `domain_rank_overview` $0.0101).
-- Backlinks `domain_intersection` is Live-only, billed per request, and subscription-gated (40204 without a Backlinks subscription).
+- Backlinks `domain_intersection` is Live-only and billed per request under pay-as-you-go; no Backlinks subscription is required as of 2026-07-01.
 - Domain Analytics `domain_technologies` bills about $0.01 per request (cost-log: $0.01); Whois overview is pricier at about $0.101.
 - `include_clickstream_data: true` doubles Labs request cost; leave it off for gap work.
 - Cadence: full gap analysis quarterly; ranked-keyword refresh monthly (Labs updates weekly).
@@ -82,3 +82,4 @@ A competitive gap pack: keyword-gap table (competitor ranks, you do not), page-l
 - https://docs.dataforseo.com/v3/dataforseo_labs/google/ranked_keywords/live/ (retrieved 2026-06-26)
 - https://docs.dataforseo.com/v3/backlinks/domain_intersection/live/ (retrieved 2026-06-26)
 - https://docs.dataforseo.com/v3/domain_analytics/technologies/domain_technologies/live/ (retrieved 2026-06-26)
+- https://dataforseo.com/update/pricing-update-in-dataforseo-apis (retrieved 2026-07-08)

--- a/wiki/hot.md
+++ b/wiki/hot.md
@@ -4,7 +4,7 @@ title: "DataForSEO Brain - Hot / Current Context"
 domain: dataforseo
 status: stable
 created: 2026-06-26
-updated: 2026-06-26
+updated: 2026-07-08
 tags: [dataforseo, hot, context]
 ---
 
@@ -12,24 +12,39 @@ tags: [dataforseo, hot, context]
 
 > Current operating context for the brain. Most recent at the top. Hub: [[index|Master Index]].
 
-## Currently true (2026-06-26)
+## Currently true (2026-07-08)
+- **Backlinks API and LLM Mentions API are now 100% pay-as-you-go.** On **2026-07-01** DataForSEO
+  cancelled all remaining monthly commitments and dropped the **$100/mo minimums** on both modules;
+  there is no subscription and no activation step. Re-verified live **2026-07-08**:
+  `/v3/backlinks/summary/live`, `/v3/backlinks/bulk_ranks/live`, and
+  `/v3/ai_optimization/llm_mentions/search/live` all now return `20000 Ok` with real data (previously
+  `40204`). New fixtures + probe log under `.raw/sources/dataforseo-research/`
+  (`_cost-log-2026-07-08-reprobe.json`). See [[cap-backlinks-api]] and [[cap-llm-mentions-visibility]].
+- `40204` ("subscription required") is now effectively **legacy** for these two modules; a pay-as-you-go
+  account no longer receives it for Backlinks or LLM Mentions.
+- The same 2026-07-01 update also **adjusted rates across selected APIs** (a broader repricing). Per-endpoint
+  price figures in the brain are due a refresh and should not be treated as exact until re-audited.
+
+## As built and first verified (2026-06-26)
 - The brain was built and live-verified against the production API on **2026-06-26**. A $5-capped
   test pass spent **$0.86** across **43 endpoints** (incl. LLM Responses for ChatGPT/Claude/Gemini/Perplexity); the ledger is `.raw/sources/dataforseo-research/_cost-log.json`.
-- Account access observed: pay-as-you-go credit is active; **Backlinks API** and **AI Optimization
-  LLM Mentions** returned `40204` (need an add-on subscription). LLM Responses (ChatGPT/Claude/Gemini/Perplexity) ARE pay-as-you-go accessible and now have live fixtures; only LLM Mentions stays gated. Backlinks + LLM Mentions shapes are documented from the
-  docs in [[cap-backlinks-api]] and [[cap-llm-mentions-visibility]].
+- Account access at build time: pay-as-you-go credit active; **Backlinks API** and **AI Optimization
+  LLM Mentions** returned `40204` (then still gated). That gate was **removed 2026-07-01** (see the
+  block above); both modules are now directly usable. LLM Responses (ChatGPT/Claude/Gemini/Perplexity)
+  were already pay-as-you-go accessible. See [[cap-backlinks-api]] and [[cap-llm-mentions-visibility]].
 - The cheapest data tier is **DataForSEO Labs** (~$0.01/call). The biggest avoidable cost is using
   **Live** when **Standard** would do; see [[dec-live-vs-standard-vs-priority]] and [[dec-cost-control-strategy]].
 
 ## Recent platform changes (2026)
-Newest first. Dates are the official DataForSEO update publication dates (source: https://dataforseo.com/updates, retrieved 2026-06-26).
+Newest first. Dates are the official DataForSEO update publication dates (source: https://dataforseo.com/updates, retrieved 2026-06-26; 2026-07-01 entry retrieved 2026-07-08).
+- **2026-07-01 - All APIs moved to 100% pay-as-you-go.** The Backlinks + LLM Mentions **$100/mo minimums were cancelled** (existing subscriptions auto-cancelled, access retained), and **rates were adjusted across selected APIs**. See [[cap-backlinks-api]] and [[cap-llm-mentions-visibility]]. Source: https://dataforseo.com/update/pricing-update-in-dataforseo-apis
 - **2026-06-10 - Amazon Merchant API gains real-time Live endpoints** (previously task-based only); Live mode for ASIN/products/sellers. See [[cap-merchant-api]].
 - **2026-05-28 - LLM Scraper (ChatGPT) returns ad results**, the sponsored placements shown inside ChatGPT responses. See [[cap-ai-optimization-api]].
 - **2026-05-05 - DataForSEO API v2 fully closed**; no new v2 requests (task_get had a ~1-month grace window). v3 only.
 - **2026-04-27 - OnPage Lighthouse API: seven new browser-simulation parameters** for device/network/browser emulation. See [[cap-onpage-api]].
 - **2026-04-21 - OnPage uncrawlable-resources endpoint** plus expanded summary data. See [[cap-onpage-api]].
 
-**Verified 2026-06-26: the Backlinks + LLM Mentions $100/mo subscriptions were NOT removed; still 40204-gated (waived only via Make/n8n/Sheets connectors).** See [[cap-backlinks-api]] and [[cap-llm-mentions-visibility]].
+**Update 2026-07-01: the Backlinks + LLM Mentions $100/mo minimums WERE removed** (both moved to pay-as-you-go). This reverses the 2026-06-26 finding that they were "NOT removed / still 40204-gated"; that was correct on 2026-06-26 and became false on 2026-07-01. Re-verified live 2026-07-08. The old Make/n8n/Sheets connector waiver is now moot (no minimum left to waive). See [[cap-backlinks-api]] and [[cap-llm-mentions-visibility]].
 
 ## Start here
 - Command center: [[DataForSEO Brain Home]] (hub) and the `DataForSEO Brain Map` canvas (Obsidian vault)
@@ -51,7 +66,7 @@ Newest first. Dates are the official DataForSEO update publication dates (source
 ## Open questions / watch list
 - AI Optimization (LLM Mentions) coverage is narrower than marketing implies and changes fast; re-verify monthly. See [[cap-ai-optimization-api]].
 - Pricing and rate limits drift; the figures in [[cap-queue-priority-cost-model]] and the source-ledger `refresh_due` are set to 2026-07-26.
-- Backlinks/LLM-Mentions add-on subscriptions are not on the test account; live fixtures for those are unavailable (documented shapes only).
+- Backlinks + LLM Mentions now have **authentic live fixtures** (captured 2026-07-08 after the pay-as-you-go move); the earlier "documented shapes only" caveat no longer applies. Broader per-endpoint repricing from 2026-07-01 is not yet fully re-audited.
 
 ## Recently added
 - **SEOus dashboard coupling (2026-06-26):** new hub [[DataForSEO Brain Home]] + fan-out
@@ -60,4 +75,4 @@ Newest first. Dates are the official DataForSEO update publication dates (source
 - 68 content notes across [[concepts/_index|concepts]], [[platforms/_index|platforms]],
   [[entities/_index|entities]], [[flows/_index|flows]], and [[decisions/_index|decisions]].
 - Research pack with 104 dated citations: [[research-pack-2026-06-26]].
-- 39 authentic live response fixtures under `.raw/sources/dataforseo-research/*/fixtures/`.
+- 42 authentic live response fixtures under `.raw/sources/dataforseo-research/*/fixtures/` (adds Backlinks summary + bulk_ranks and LLM Mentions search, captured 2026-07-08).

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -4,13 +4,20 @@ title: "DataForSEO Brain - Build & Change Log"
 domain: dataforseo
 status: stable
 created: 2026-06-26
-updated: 2026-06-26
+updated: 2026-07-08
 tags: [dataforseo, log, changelog]
 ---
 
 # DataForSEO Brain - Build & Change Log
 
 > Append-only; newest on top. Hub: [[index|Master Index]].
+
+## 2026-07-08 - Backlinks + LLM Mentions pay-as-you-go correction
+Corrected the cross-cutting brain state after DataForSEO's 2026-07-01 pricing update moved all endpoints to pay-as-you-go and cancelled the Backlinks and LLM Mentions monthly commitments.
+
+- **Access correction:** Backlinks and LLM Mentions were gated through 2026-06-26, but the gate was removed 2026-07-01. Live re-probe on 2026-07-08 returned `20000 Ok` for `/v3/backlinks/summary/live`, `/v3/backlinks/bulk_ranks/live`, and `/v3/ai_optimization/llm_mentions/search/live`.
+- **40204:** kept in [[cap-status-error-codes]] as a defined code, reframed as legacy for these modules.
+- **Evidence:** official pricing update plus fixtures under `.raw/sources/dataforseo-research/` and `_cost-log-2026-07-08-reprobe.json`.
 
 ## 2026-06-26 - Mega review + gap-fill (v1.0.1)
 A full review pass: an ultracode 7-reviewer Workflow + 4 deep-dives (currency, Backlinks, AI Optimization) + a claude-obsidian wiki-lint.

--- a/wiki/meta/dashboard.md
+++ b/wiki/meta/dashboard.md
@@ -4,7 +4,7 @@ title: "DataForSEO Brain - Operator Dashboard"
 domain: dataforseo
 status: stable
 created: 2026-06-26
-updated: 2026-06-26
+updated: 2026-07-08
 tags: [dataforseo, meta, dashboard, health]
 ---
 
@@ -20,10 +20,10 @@ the machine-readable contract is `references/dashboard-map.json`.
 |---|---|---|---|
 | `/dashboard/serp` | SERP | [[cap-serp-api]], [[cap-serp-google-verticals]], [[cap-serp-non-google-engines]] | live |
 | `/dashboard/keyword-overview` | Keywords + Labs | [[cap-keywords-data-api]], [[cap-labs-keyword-research]] | live |
-| `/dashboard/backlinks` | Backlinks | [[cap-backlinks-api]], [[cap-backlinks-bulk-metrics]] | gated (40204) |
+| `/dashboard/backlinks` | Backlinks | [[cap-backlinks-api]], [[cap-backlinks-bulk-metrics]] | pay-as-you-go |
 | `/dashboard/on-page` | OnPage + Content + Domain | [[cap-onpage-api]], [[cap-content-analysis-api]], [[cap-domain-analytics]] | live |
 | `/dashboard/local-finder` | Business Data | [[cap-business-data-api]] | live |
-| `/dashboard/ai-optimization` | AI Optimization | [[cap-ai-optimization-api]], [[cap-llm-mentions-visibility]] | partial (Mentions gated) |
+| `/dashboard/ai-optimization` | AI Optimization | [[cap-ai-optimization-api]], [[cap-llm-mentions-visibility]] | live (Mentions pay-as-you-go) |
 | `/dashboard/merchant` | Merchant + App Data | [[cap-merchant-api]], [[cap-app-data-api]] | planned |
 | `/dashboard/ledger` | Platform + Databases | [[cap-queue-priority-cost-model]], [[cap-databases]] | planned |
 | `/dashboard/autocomplete` | Free (no cost) | [[cap-keywords-data-api]] | planned |
@@ -31,19 +31,19 @@ the machine-readable contract is `references/dashboard-map.json`.
 ## Module coverage matrix
 Every module has a capability concept note, raw endpoint docs, and (where accessible) a live fixture.
 
-| Module | Concept note | Live-tested 2026-06-26 |
+| Module | Concept note | Live-tested status |
 |---|---|---|
 | SERP | [[cap-serp-api]], [[cap-serp-google-verticals]], [[cap-serp-non-google-engines]] | yes (organic/maps/bing/youtube/news/images) |
 | Keywords Data | [[cap-keywords-data-api]], [[cap-trends-and-clickstream]] | yes (Ads volume, Trends, clickstream) |
 | DataForSEO Labs | [[cap-labs-keyword-research]], [[cap-labs-competitor-research]], [[cap-labs-market-analysis]] | yes (20 endpoints) |
-| Backlinks | [[cap-backlinks-api]], [[cap-backlinks-bulk-metrics]] | no - needs add-on subscription (40204) |
+| Backlinks | [[cap-backlinks-api]], [[cap-backlinks-bulk-metrics]] | yes (summary + bulk_ranks re-probed 2026-07-08) |
 | OnPage | [[cap-onpage-api]] | yes (instant_pages) |
 | Domain Analytics | [[cap-domain-analytics]] | yes (technologies, whois) |
 | Content Analysis | [[cap-content-analysis-api]] | yes (search, summary) |
 | Merchant | [[cap-merchant-api]] | partial (Shopping is Standard-only) |
 | App Data | [[cap-app-data-api]] | documented |
 | Business Data | [[cap-business-data-api]] | yes (business listings) |
-| AI Optimization | [[cap-ai-optimization-api]], [[cap-llm-mentions-visibility]] | LLM Responses live (4 models); LLM Mentions needs add-on (40204) |
+| AI Optimization | [[cap-ai-optimization-api]], [[cap-llm-mentions-visibility]] | LLM Responses live (4 models); LLM Mentions search live 2026-07-08 |
 | Databases | [[cap-databases]] | documented (bulk delivery) |
 
 ## Cost cheat-sheet (live-observed 2026-06-26)
@@ -57,12 +57,12 @@ Every module has a capability concept note, raw endpoint docs, and (where access
 | Higher | Whois overview | ~$0.101 |
 | Highest tested | Clickstream search volume ([[ent-clickstream-data]]) | ~$0.150 |
 
-Full ledger: `.raw/sources/dataforseo-research/_cost-log.json`. Strategy: [[dec-cost-control-strategy]].
+Full ledger: `.raw/sources/dataforseo-research/_cost-log.json`; 2026-07-08 Backlinks and LLM Mentions re-probe ledger: `.raw/sources/dataforseo-research/_cost-log-2026-07-08-reprobe.json`. Strategy: [[dec-cost-control-strategy]].
 
 ## Substance-gate status (targets the audit enforces)
 - Wiki notes: 68 content notes + hubs, every note >= 80 lines and >= 8 wikilinks. Gate: avg >= 80 lines, >= 8 links.
 - Research pack: [[research-pack-2026-06-26]] with 104 dated citations. Gate: >= 60.
-- Sources ledger: 12 official/vendor sources, refresh_due 2026-07-26. Gate: >= 2 official.
+- Sources ledger: 13 official/vendor sources, refresh_due 2026-07-26. Gate: >= 2 official.
 
 ## Navigation
 [[concepts/_index]] · [[platforms/_index]] · [[entities/_index]] · [[flows/_index]] · [[decisions/_index]] · [[sources/_index]]

--- a/wiki/overview.md
+++ b/wiki/overview.md
@@ -4,14 +4,15 @@ title: "DataForSEO Brain - Overview"
 domain: dataforseo
 status: stable
 created: 2026-06-26
-updated: 2026-06-26
+updated: 2026-07-08
 tags: [dataforseo, overview, orientation]
 ---
 
 # DataForSEO Brain - Overview
 
 > What DataForSEO is, how it is shaped, and how to navigate this brain. Live-verified against the
-> production API on 2026-06-26 (a $5-capped test pass spending $0.85 across 39 endpoints).
+> production API on 2026-06-26 (a $5-capped test pass spending $0.85 across 39 endpoints);
+> Backlinks and LLM Mentions access re-verified 2026-07-08 after the pay-as-you-go move.
 
 ## What DataForSEO is
 DataForSEO is a **raw SEO-data API provider**, not a dashboard. You send REST requests and get back
@@ -67,8 +68,8 @@ tools, governed by a cost-control spine (Standard-vs-Live, Labs-first, result ca
 ledger). The brain is its knowledge layer: the hub [[DataForSEO Brain Home]] groups every capability
 into the eight SEOus tool groups, the `DataForSEO Brain Map` canvas (Obsidian vault) draws the
 fan-out, and `references/dashboard-map.json` is the route ↔ capability ↔ playbook contract both sides
-read. Backlinks and LLM Mentions appear as graceful "subscription required" tools until their add-ons
-are activated.
+read. Backlinks and LLM Mentions are now directly usable in pay-as-you-go mode since 2026-07-01,
+with live fixtures captured from the 2026-07-08 re-probe.
 
 ## How to navigate this brain
 - Start with the router: [[dec-which-api-for-which-job]].
@@ -82,3 +83,4 @@ are activated.
 ## Sources
 - DataForSEO API v3 documentation - https://docs.dataforseo.com/v3/ - retrieved 2026-06-26
 - DataForSEO pricing - https://dataforseo.com/pricing - retrieved 2026-06-26
+- DataForSEO pricing update - https://dataforseo.com/update/pricing-update-in-dataforseo-apis - retrieved 2026-07-08

--- a/wiki/platforms/plat-ai-assistants.md
+++ b/wiki/platforms/plat-ai-assistants.md
@@ -5,7 +5,7 @@ domain: dataforseo
 subdomain: ai-optimization
 status: stable
 created: 2026-06-26
-updated: 2026-06-26
+updated: 2026-07-08
 tags: [dataforseo, platform, ai-optimization, geo, llm]
 related:
   - "[[cap-ai-optimization-api]]"
@@ -38,7 +38,7 @@ Generative engines are now a discovery surface alongside classic search, and Dat
 - Aggregation endpoints group by location, language, platform, `sources_domain[]`, `search_results_domain[]`, `brand_entities_title[]`, with `mentions` and `ai_search_volume` per group (`impressions` is deprecated and returns null).
 
 ## Cost & method notes
-- Per the research report and live pricing pages: LLM Responses costs $0.0006 per task plus the underlying model token charge on Live, or $0.0002 plus a $0.01 refundable prepayment per task on Standard; LLM Scraper (ChatGPT and Gemini only) about $0.0012 per page Standard, $0.0024 Priority, $0.004 Live (approximate); LLM Mentions about $0.10 per request plus $0.001 per row with a $100 monthly minimum; AI Keyword Data about $0.01 per task plus $0.0001 per keyword.
+- Per the research report and live pricing pages: LLM Responses costs $0.0006 per task plus the underlying model token charge on Live, or $0.0002 plus a $0.01 refundable prepayment per task on Standard; LLM Scraper (ChatGPT and Gemini only) about $0.0012 per page Standard, $0.0024 Priority, $0.004 Live (approximate); LLM Mentions about $0.10 per request plus $0.001 per row, roughly $1.10 per 1,000 rows and no monthly minimum since 2026-07-01; AI Keyword Data about $0.01 per task plus $0.0001 per keyword.
 - LLM Responses, Scraper, and Mentions all run up to 120s with 30 concurrent Live tasks per platform; 2000 calls/min. See [[cap-rate-limits-throughput]] and [[cap-task-vs-live-execution]].
 
 ## When to use / how it fits
@@ -81,3 +81,5 @@ Generative engines are now a discovery surface alongside classic search, and Dat
 - https://dataforseo.com/pricing/ai-optimization/llm-responses - retrieved 2026-06-26
 - https://dataforseo.com/pricing/ai-optimization/llm-scraper - retrieved 2026-06-26
 - https://arxiv.org/abs/2311.09735 - retrieved 2026-06-26
+- https://dataforseo.com/update/pricing-update-in-dataforseo-apis - published 2026-07-01, retrieved 2026-07-08
+- https://dataforseo.com/pricing/ai-optimization/llm-mentions - retrieved 2026-07-08


### PR DESCRIPTION
## What changed and why

On **2026-07-01** DataForSEO published a pricing update that **cancelled all remaining monthly commitments** and moved every endpoint to a **100% pay-as-you-go** model. The **$100/mo minimums** on the **Backlinks API** and **LLM Mentions API** were removed (existing subscriptions auto-cancelled, access retained).

The brain asserted the opposite. As of 2026-06-26 it documented both modules as subscription-gated (`40204`), and `cap-backlinks-api` even carried an authoritative "the subscription was **NOT removed**" debunk. That was accurate on 2026-06-26 and became **false on 2026-07-01**. This PR corrects the brain across 24 files.

## Verification

- **Web:** confirmed against the official [pricing update](https://dataforseo.com/update/pricing-update-in-dataforseo-apis) and the Backlinks / LLM Mentions help-center subscription pages.
- **Live re-probe (2026-07-08):** hit the production API. Previously-`40204` endpoints now return `20000 Ok` with real data:
  - `/v3/backlinks/summary/live` -> `20000` (dataforseo.com: 347,004 backlinks, rank 323), ~$0.024
  - `/v3/backlinks/bulk_ranks/live` -> `20000`, ~$0.024
  - `/v3/ai_optimization/llm_mentions/search/live` -> `20000`, ~$0.105
  - Total probe spend: **$0.153**. Captured the first authentic Backlinks + LLM Mentions fixtures (local `.raw/`, gitignored per repo convention) plus a dated re-probe cost log.

## Changes

- **Timeline honesty:** every correction keeps the record straight - gated through 2026-06-26, removed 2026-07-01. No silent deletions of the old claim.
- **40204** reframed as a **defined-but-legacy** code for these modules (kept in the error catalog; no longer returned on a pay-as-you-go account).
- **`dashboard-map.json`** gate flags flipped (`gated` / `gated_partial` -> `false`) with rewritten gate notes.
- **`source-ledger.json`** gains a dated pricing-update source; the two Backlinks / LLM-Mentions claim rows updated with the re-probe result.
- Hub (`DataForSEO Brain Home`), operator dashboard, overview, hot cache, `current-requirements`, `CHANGELOG`, and build log all corrected.

## Gates

- `audit_brain.py --require market-ready`: **market-ready, score 100**
- `pytest`: **6 passed** (the CI gate)
- No em dashes; all touched JSON validates.

## Notes / out of scope

- `tests/test_pipeline.py` has a **pre-existing, date-dependent** failure: `build_demo_vault.py` stamps today's date into the demo vault, so `package_release --release-type market-ready` blocks on "dirty tracked files" before reaching the market-ready check, which the test's assertion string doesn't match. Unrelated to this content change (CI runs pytest, not this self-test). Flagging for a separate fix.
- The broader 2026-07-01 update also "adjusted rates across selected APIs." Per-endpoint pricing was **not** fully re-audited here; `hot.md` and `current-requirements` note that pricing figures are due a refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)