### PR TITLE
docs: add walkthrough video to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@
 
 ---
 
+## Watch the walkthrough
+
+<div align="center">
+
+<a href="https://www.youtube.com/watch?v=svD6nQNQDMM"><img src="https://i.ytimg.com/vi/svD6nQNQDMM/maxresdefault.jpg" alt="Watch: I Built a DataForSEO Brain for Claude Code" width="640"></a>
+
+**▶ [I Built a DataForSEO Brain for Claude Code](https://www.youtube.com/watch?v=svD6nQNQDMM)**
+
+</div>
+
 ## Why it exists
 
 - **Pick the right call, the first time.** A 12-module, ~200+ endpoint surface is easy to get wrong. The brain routes job to endpoint and flags the cost footguns (Live vs Standard, depth, priority).

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 <img src="assets/dataforseo-hero.png" alt="DataForSEO Brain - a source-cited operating memory for the DataForSEO v3 API" width="860">
 
 [![Live docs](https://img.shields.io/badge/docs-live%20site-3b82f6)](https://agricidaniel.github.io/dataforseo-brain/)
+[![Watch on YouTube](https://img.shields.io/badge/▶%20watch-on%20YouTube-red?logo=youtube&logoColor=white)](https://www.youtube.com/watch?v=svD6nQNQDMM)
 [![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 [![Notes](https://img.shields.io/badge/wiki%20notes-76-3b82f6)](wiki/index.md)
 [![Modules](https://img.shields.io/badge/API%20modules-12-4caf50)](wiki/concepts/cap-platform-architecture.md)


### PR DESCRIPTION
Adds a **Watch the walkthrough** section to the top of the README, right under the hero.

- Centered, clickable poster (YouTube maxres thumbnail) that opens the video.
- Titled **I Built a DataForSEO Brain for Claude Code** -> https://www.youtube.com/watch?v=svD6nQNQDMM
- Plain H2 to match the repo's existing heading style (no emoji).

GitHub markdown can't embed a playable iframe, so a linked thumbnail is the native pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)