### PR TITLE
Correct WHOIS registered-flag lifecycle note with live evidence

### DIFF
--- a/references/source-ledger.json
+++ b/references/source-ledger.json
@@ -216,6 +216,21 @@
         "Official MCP server exposes 10 DataForSEO modules to agents",
         "Configured via DATAFORSEO_USERNAME/PASSWORD and ENABLED_MODULES"
       ]
+    },
+    {
+      "id": "dfs-whois-registered-drop-lifecycle",
+      "title": "WHOIS Overview registered flag during the drop lifecycle (live observation)",
+      "url": "https://docs.dataforseo.com/v3/domain_analytics/whois/overview/live/",
+      "type": "primary",
+      "source_type": "primary",
+      "retrieved": "2026-07-17",
+      "refresh_due": "2026-10-17",
+      "version": "v3 as of 2026-07-17",
+      "confidence": "high",
+      "claims": [
+        "All 461 live WHOIS Overview candidates in redemption_period/pending_delete EPP status returned registered=true (2026-07-17 run)",
+        "Filtering registered=false together with drop-status EPP codes returns zero rows; registered flips to false only after the final drop"
+      ]
     }
   ],
   "provenance": "Populated 2026-06-26 from official docs.dataforseo.com/v3 + a $5-capped live API test pass. Updated 2026-07-08 for the 2026-07-01 pay-as-you-go move and live Backlinks/LLM Mentions re-probe."

--- a/wiki/concepts/cap-domain-analytics.md
+++ b/wiki/concepts/cap-domain-analytics.md
@@ -5,7 +5,7 @@ domain: dataforseo
 subdomain: domain-analytics
 status: stable
 created: 2026-06-26
-updated: 2026-06-26
+updated: 2026-07-17
 tags: [dataforseo, domain-analytics, technographics]
 related:
   - "[[cap-backlinks-api]]"
@@ -56,7 +56,7 @@ Domain Analytics powers the technographic and ownership legs of [[play-competito
 - Selector arrays cap at 10 entries; filters cap at 8; sort rules cap at 3.
 - domains_by_technology requires limit + offset <= 10,000; use `offset_token` beyond 100,000 results.
 - Technologies reflects the last crawl (`last_visited`), so very new or very small sites may be stale or absent.
-- Whois `registered` is false when a domain has expired, which is itself a useful drop-catching signal.
+- Whois `registered` stays `true` while a domain is in `redemption_period`/`pending_delete` (it is still in the registry and restorable) and only flips to `false` after the final drop. Combining a `registered = false` filter with drop-status EPP codes therefore matches nothing; use `registered = false` as the expiry signal only in date-only queries with no status filter. Observed live 2026-07-17: 461/461 drop-status candidates returned `registered: true`.
 - The Whois `metrics` and `backlinks_info` enrichment is sourced from DataForSEO's own backlink index, so coverage tracks that index rather than the live web.
 - aggregation_technologies internal list limits (`internal_groups_list_limit`, `internal_categories_list_limit`, `internal_technologies_list_limit`) default to 5/5/10 and can be overridden by `internal_list_limit`.
 
@@ -78,3 +78,4 @@ Domain Analytics powers the technographic and ownership legs of [[play-competito
 - https://docs.dataforseo.com/v3/domain_analytics/technologies/technologies_summary/live/ (retrieved 2026-06-26)
 - https://docs.dataforseo.com/v3/domain_analytics/technologies/domains_by_technology/live/ (retrieved 2026-06-26)
 - https://docs.dataforseo.com/v3/domain_analytics/whois/overview/live/ (retrieved 2026-06-26)
+- Live WHOIS Overview probe: all 461 candidates in redemption_period/pending_delete EPP status returned registered=true (observed 2026-07-17)


### PR DESCRIPTION
## What changed

- **wiki/concepts/cap-domain-analytics.md:** the gotcha "Whois `registered` is false when a domain has expired" is corrected: the flag stays `true` through `redemption_period`/`pending_delete` (the domain is still in the registry and restorable) and only flips `false` after the final drop. Added the practical consequence: combining `registered = false` with drop-status EPP filters matches nothing; `registered = false` is the right expiry signal only for date-only queries. Frontmatter `updated` bumped; dated evidence line added to Sources.
- **references/source-ledger.json:** new `primary` entry (`dfs-whois-registered-drop-lifecycle`, retrieved 2026-07-17, refresh due 2026-10-17) recording the observation per the repo's research-evidence rule.

## Why

The old wording caused a real downstream bug: an expired-domain finder built on this brain added a `registered=false` WHOIS seed filter alongside drop-status EPP codes and every drop-mode run returned 0 candidates while still billing the WHOIS base fee. A live probe on 2026-07-17 confirmed the lifecycle: **461/461** WHOIS Overview candidates in redemption/pending-delete status returned `registered: true`.

## Reviewer notes

- `python scripts/audit_brain.py --json` passes after the change: `market_ready: true`, no critical failures. (First attempt used `source_type: live-observation`, which the audit correctly rejected; the entry uses the accepted `primary` type.)
- No other wiki pages state the old claim (checked repo-wide).